### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/tips64.md
+++ b/tips64.md
@@ -618,7 +618,7 @@ export LD_LIBRARY_PATH=/usr/local/lib
 /*
 #include "secp256k1.h"
 
-#cgo LDFLAGS: -lsecp256k1
+# cgo LDFLAGS: -lsecp256k1
 */
 import "C"
 import "unsafe"
@@ -1127,7 +1127,7 @@ package main
 /*
 #include <stdlib.h>
 #include <openssl/sha.h>    
-#cgo LDFLAGS: -lcrypto
+# cgo LDFLAGS: -lcrypto
 */
 import "C"
 import (


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
